### PR TITLE
修复 zap customfields 报错

### DIFF
--- a/otellog/otelzap/logger.go
+++ b/otellog/otelzap/logger.go
@@ -109,6 +109,6 @@ func GetOptions(cwZap cwZap) []cwzap.Option {
 		Ws:  cwZap.coreConfig.Ws,
 	}))
 	opions = append(opions, cwzap.WithZapOptions(cwZap.zapOpts...))
-	opions = append(opions, cwzap.WithCustomFields(cwZap.customFields))
+	opions = append(opions, cwzap.WithCustomFields(cwZap.customFields...))
 	return opions
 }


### PR DESCRIPTION
调用zap配置文件时，会出现 Ignored key without a value. 报错。修改了参数传递方式